### PR TITLE
New parameters for to-maven goal

### DIFF
--- a/src/main/resources/org/apache/maven/plugin/eclipse/messages.properties
+++ b/src/main/resources/org/apache/maven/plugin/eclipse/messages.properties
@@ -68,7 +68,7 @@ EclipseToMavenMojo.remoterepositorydeployto=Will deploy artifacts to remote repo
 EclipseToMavenMojo.processingfile=Processing file {0}
 EclipseToMavenMojo.processingplugin=Processing {0} of {1}
 EclipseToMavenMojo.skippingfile=Skipping file {0}
-EclipseToMavenMojo.unabletoresolveversionrange=Unable to resolve version range for dependency {0} in project {1}
+EclipseToMavenMojo.invalidversionrange=Invalid version range for dependency {0} of plugin {1}
 EclipseToMavenMojo.unabletoaccessjar=Unable to access jar {0}
 EclipseToMavenMojo.plugindoesnothavemanifest=Plugin {0} does not have a manifest; skipping..
 EclipseToMavenMojo.unabletoreadbundlefrommanifest=Unable to read bundle name/version from manifest, skipping...
@@ -81,6 +81,11 @@ EclipseToMavenMojo.invalidsyntaxforrepository=Invalid syntax for repository.
 EclipseToMavenMojo.invalidremoterepositorysyntax=Invalid syntax for remote repository. Use "id::layout::url".
 EclipseToMavenMojo.cannotfindrepositorylayout=Cannot find repository layout: {0}
 EclipseToMavenMojo.missingversionforbundle=Missing version for bundle {0}, assuming any version > 0
+EclipseToMavenMojo.searchingplugins=Searching plugins in directory {0}.
+EclipseToMavenMojo.pluginsfound=Found {1} plugins in directory {0}.
+EclipseToMavenMojo.attachedsourceplugins=Attached {0} source plugins.
+EclipseToMavenMojo.deploymainartifacts=Deploying {0} main artifacts.
+EclipseToMavenMojo.deployedmainartifacts=Deployed {0} main artifacts.
 
 AbstractIdeSupportMojo.sourcesnotavailable=\n       Sources for some artifacts are not available.\n       List of artifacts without a source archive:
 AbstractIdeSupportMojo.sourcesnotdownloaded=\n       Sources for some artifacts are not available.\n       Please run the same goal with the -DdownloadSources=true parameter in order to check remote repositories for sources.\n       List of artifacts without a source archive:

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -62,11 +62,9 @@ ${project.name}
 
 *** Specific goals for PDE developments
 
-  * {{{./to-maven-mojo.html}eclipse:to-maven}} Add eclipse artifacts from an eclipse installation
-  to the local repo. This mojo automatically analize the eclipse directory, copy plugins jars
-  to the local maven repo, and generates appropriate poms. This is the official central repository
-  builder for Eclipse plugins, so it has the necessary default values. For customized repositories
-  see {{{./make-artifacts-mojo.html}eclipse:make-artifacts}}.
+  * {{{./to-maven-mojo.html}eclipse:to-maven}} Add Eclipse artifacts an Eclipse installation or a
+  local P2 repo to the local Maven repo. This mojo automatically analyzes the local P2 repo, copies
+  jars from the plugins directory to the local maven repo, and generates appropriate poms.
 
   * {{{./install-plugins-mojo.html}eclipse:install-plugins}} installs all resolved project
   dependencies of a particular type (usually 'eclipse-plugin') into the specified Eclipse

--- a/src/test/java/org/apache/maven/plugin/eclipse/EclipseToMavenTest.java
+++ b/src/test/java/org/apache/maven/plugin/eclipse/EclipseToMavenTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugin.eclipse;
 import junit.framework.TestCase;
 
 import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.util.ReflectionUtils;
 
 /**
  * @author Fabrizio Giustina
@@ -44,6 +45,7 @@ public class EclipseToMavenTest
     {
         super.setUp();
         mojo = new EclipseToMavenMojo();
+        ReflectionUtils.setVariableValueInObject( mojo, "groupIdTokens", Integer.valueOf( -1 ));  // Default, normally injected
     }
 
     /**
@@ -105,26 +107,49 @@ public class EclipseToMavenTest
 
     /**
      * Test the generation of a groupId from a bundle symbolic name.
+     * @throws IllegalAccessException
      */
-    public void testCreateGroupId()
+    public void testCreateGroupId() throws IllegalAccessException
     {
         assertEquals( "test", mojo.createGroupId( "test" ) );
         assertEquals( "org", mojo.createGroupId( "org.eclipse" ) );
         assertEquals( "org.eclipse", mojo.createGroupId( "org.eclipse.jdt" ) );
         assertEquals( "org.eclipse.jdt", mojo.createGroupId( "org.eclipse.jdt.apt" ) );
         assertEquals( "org.eclipse.jdt.apt", mojo.createGroupId( "org.eclipse.jdt.apt.core" ) );
+
+        ReflectionUtils.setVariableValueInObject( mojo, "groupIdTokens", Integer.valueOf( 3 ));
+        assertEquals( "test", mojo.createGroupId( "test" ) );
+        assertEquals( "org.eclipse", mojo.createGroupId( "org.eclipse" ) );
+        assertEquals( "org.eclipse.jdt", mojo.createGroupId( "org.eclipse.jdt" ) );
+        assertEquals( "org.eclipse.jdt", mojo.createGroupId( "org.eclipse.jdt.apt" ) );
+        assertEquals( "org.eclipse.jdt", mojo.createGroupId( "org.eclipse.jdt.apt.core" ) );
     }
 
     /**
      * Test the generation of a artifactId from a bundle symbolic name.
+     * @throws IllegalAccessException
      */
-    public void testCreateArtifactId()
+    public void testCreateArtifactId() throws IllegalAccessException
     {
         assertEquals( "test", mojo.createArtifactId( "test" ) );
         assertEquals( "eclipse", mojo.createArtifactId( "org.eclipse" ) );
         assertEquals( "jdt", mojo.createArtifactId( "org.eclipse.jdt" ) );
         assertEquals( "apt", mojo.createArtifactId( "org.eclipse.jdt.apt" ) );
         assertEquals( "core", mojo.createArtifactId( "org.eclipse.jdt.apt.core" ) );
+
+        ReflectionUtils.setVariableValueInObject( mojo, "groupIdTokens", Integer.valueOf( 3 ));
+        assertEquals( "test", mojo.createArtifactId( "test" ) );
+        assertEquals( "org.eclipse", mojo.createArtifactId( "org.eclipse" ) );
+        assertEquals( "org.eclipse.jdt", mojo.createArtifactId( "org.eclipse.jdt" ) );
+        assertEquals( "apt", mojo.createArtifactId( "org.eclipse.jdt.apt" ) );
+        assertEquals( "apt.core", mojo.createArtifactId( "org.eclipse.jdt.apt.core" ) );
+
+        ReflectionUtils.setVariableValueInObject( mojo, "useBundleNameAsArtifactId", Boolean.TRUE );
+        assertEquals( "test", mojo.createArtifactId( "test" ) );
+        assertEquals( "org.eclipse", mojo.createArtifactId( "org.eclipse" ) );
+        assertEquals( "org.eclipse.jdt", mojo.createArtifactId( "org.eclipse.jdt" ) );
+        assertEquals( "org.eclipse.jdt.apt", mojo.createArtifactId( "org.eclipse.jdt.apt" ) );
+        assertEquals( "org.eclipse.jdt.apt.core", mojo.createArtifactId( "org.eclipse.jdt.apt.core" ) );
     }
 
     public void testOsgiVersionToMavenVersion()


### PR DESCRIPTION
The to-maven goal will generate groupId and artifactId from the bundle name splitting it at the dots and using the last token as artifactId and the the other tokens as groupId. Since the artifactId will also determine the base name of the resulting jar, we end up with a lot jar files using the same names (e.g. core.jar or common.jar).

Looking at Central you can see that typically the first three tokens of the bundle name are used for the groupId and often the bundle name itself is nevertheless used as artifactId (e.g. [jgit](https://search.maven.org/search?q=g:org.eclipse.jgit)).

The pull request adds to parameter to the goal, one for the number of tokens used for the groupId and a flag to use the bundle name itself as artifactId.